### PR TITLE
Modifications to have Data Hub compliant model

### DIFF
--- a/model-desc/ctdc_model_file.yaml
+++ b/model-desc/ctdc_model_file.yaml
@@ -45,6 +45,7 @@ Nodes:
       Class: primary
       Template: 'Yes'
     Props:
+      - pi_id
       - person_first_name #2179589
       - person_last_name #2179591
       - person_middle_name #2179590

--- a/model-desc/ctdc_model_properties_file.yaml
+++ b/model-desc/ctdc_model_properties_file.yaml
@@ -295,7 +295,6 @@ PropDefinitions:
     Src: ICDC
     Type: string
     Req: 'Yes'
-    Key: true
     Tags:
       Labeled: Collection
   image_type_included:

--- a/model-desc/ctdc_model_properties_file.yaml
+++ b/model-desc/ctdc_model_properties_file.yaml
@@ -177,6 +177,12 @@ PropDefinitions:
     Type: string
     Req: 'Yes'
   # principal_investigator
+  pi_id: 
+    Desc: A globally unique identifier via which principle investigator can be differentiated across studies; specifically the value of study_id concatenated with the value of pi_last_name, <br>This property is used as the key via which child records, e.g. cohort records, can be associated with the appropriate principle investigator, and to identify the correct principle investigator records during data updates.
+    Src: Data Onwer(s)
+    Type: string
+    Req: 'Yes'
+    Key: true
   person_first_name: #formerly principal_investigator_first_name
     Desc: <A word or group of words indicating a person's first (personal or given)
       name; the name that precedes the surname. Synonym = Given Name.> The first or


### PR DESCRIPTION
This PR includes:

- The addition of a unique "key" prop for the principal_investigator node.
- The removal of a second instance of a "key" prop from the image_collection node.