### PR TITLE
Update names of key properties

### DIFF
--- a/model-desc/ctdc_model_file.yaml
+++ b/model-desc/ctdc_model_file.yaml
@@ -45,7 +45,7 @@ Nodes:
       Class: primary
       Template: 'Yes'
     Props:
-      - pi_id
+      - person_record_id
       - person_first_name #2179589
       - person_last_name #2179591
       - person_middle_name #2179590
@@ -72,7 +72,7 @@ Nodes:
       Class: secondary
       Template: 'Yes'
     Props:
-      - associated_link_id #14822135
+      - associated_link_record_id #14822135
       - associated_link_name #14822136
       - associated_link_url #14822140
   image_collection:
@@ -83,7 +83,7 @@ Nodes:
       Class: secondary
       Template: 'Yes'
     Props:
-      - image_collection_id #14822135
+      - image_collection_record_id #14822135
       - image_collection_name #14826008
       - image_type_included #12137353
       - image_collection_url #11556141
@@ -110,7 +110,7 @@ Nodes:
       Class: primary
       Template: 'Yes'
     Props:
-      - demographic_id #14822135
+      - demographic_record_id #14822135
       #- age_at_diagnosis
       - age_at_enrollment #12299548
       - race #2192199
@@ -144,7 +144,7 @@ Nodes:
       Class: primary
       Template: 'Yes'
     Props:
-      - diagnosis_id #14822135
+      - diagnosis_record_id #14822135
       - primary_diagnosis_disease_group #14905532
       #- icd_10_disease_code #11479873
       - ctep_disease_term #4723846
@@ -168,7 +168,7 @@ Nodes:
       Class: secondary
       Template: 'Yes'
     Props:
-      - targeted_therapy_id #14822135
+      - targeted_therapy_record_id #14822135
       - targeted_therapy #14913015
       - targeted_therapy_dose #2182728
       - targeted_therapy_dose_units #2321160
@@ -184,7 +184,7 @@ Nodes:
       Class: secondary
       Template: 'Yes'
     Props:
-      - non_targeted_therapy_id #14822135
+      - non_targeted_therapy_record_id #14822135
       - non_targeted_therapy #14913015
       - non_targeted_therapy_dose #2182728
       - non_targeted_therapy_dose_units #2321160
@@ -200,7 +200,7 @@ Nodes:
       Class: secondary
       Template: 'Yes'
     Props:
-      - surgical_procedure_id #14822135
+      - surgical_procedure_record_id #14822135
       - surgical_procedure #13383457 #6411539
       - surgical_procedure_date
       - surgical_procedure_anatomical_location
@@ -215,7 +215,7 @@ Nodes:
       Class: secondary
       Template: 'Yes'
     Props:
-      - radiological_procedure_id #14822135
+      - radiological_procedure_record_id #14822135
       - radiological_procedure #6411539
       - radiological_procedure_anatomical_location
       - radiation_dose
@@ -233,7 +233,7 @@ Nodes:
       Class: secondary
       Template: 'Yes'
     Props:
-      - subject_status_id #14822135
+      - subject_status_record_id #14822135
       - survival_status #2847330
       - primary_cause_of_death #4783274
       - off_study #14834973
@@ -246,7 +246,7 @@ Nodes:
       Class: primary
       Template: 'Yes'
     Props:
-      - specimen_id #14986441
+      - specimen_record_id #14986441
       - parent_specimen_id #14986442
       - parent_specimen_type #14986443 # this refers to the nature of the specimen originally isolated from the participant, and from which various aliquots and/or derivative biospecimens were subseuqently isolated
       - specimen_type #11253427 # this refers to the nature of the sub-specimen that was actually subject to downstream analysis

--- a/model-desc/ctdc_model_properties_file.yaml
+++ b/model-desc/ctdc_model_properties_file.yaml
@@ -177,7 +177,7 @@ PropDefinitions:
     Type: string
     Req: 'Yes'
   # principal_investigator
-  pi_id: 
+  person_record_id: 
     Desc: A globally unique identifier via which principle investigator can be differentiated across studies; specifically the value of study_id concatenated with the value of pi_last_name, <br>This property is used as the key via which child records, e.g. cohort records, can be associated with the appropriate principle investigator, and to identify the correct principle investigator records during data updates.
     Src: Data Onwer(s)
     Type: string
@@ -232,7 +232,7 @@ PropDefinitions:
     Type: string
     Req: Preferred
   # associated_link
-  associated_link_id:
+  associated_link_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related
       records.> A unique identifier of each associated link record, used to identify
       the correct associated link records during data updates. <br>CDE ID = 14822135
@@ -270,7 +270,7 @@ PropDefinitions:
     Type: string
     Req: 'Yes'
   # image collection props
-  image_collection_id:
+  image_collection_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related
       records.> A unique identifier of each image collection record, used to identify
       the correct image collection records during data updates. <br>CDE ID = 14822135
@@ -438,7 +438,7 @@ PropDefinitions:
       - Unknown
     Req: Preferred
   # demographic
-  demographic_id:
+  demographic_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related
       records.> A unique identifier of each demographic record, used to identify the
       correct demographic records during data updates. <br>The value of this property
@@ -709,7 +709,7 @@ PropDefinitions:
       - Unknown
     Req: 'Yes'
   # diagnosis
-  diagnosis_id:
+  diagnosis_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related
       records.> A unique identifier of each diagnosisc record, used to identify the
       correct diagnosis records during data updates. <br>The value of this property
@@ -1021,7 +1021,7 @@ PropDefinitions:
   #     value_type: number
   #   Req: 'Yes'
   # targeted_therapy
-  targeted_therapy_id:
+  targeted_therapy_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related
       records.> A unique identifier of each targeted therapy record, used to identify
       the correct targeted therapy records during data updates. <br>CDE ID = 14822135
@@ -1141,7 +1141,7 @@ PropDefinitions:
       - Unknown
     Req: Preferred
   # non_targeted_therapy
-  non_targeted_therapy_id:
+  non_targeted_therapy_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related
       records.> A unique identifier of each non-targeted therapy record, used to identify
       the correct non-targeted therapy records during data updates. <br>CDE ID = 14822135
@@ -1261,7 +1261,7 @@ PropDefinitions:
       - Unknown
     Req: 'Yes'
   # surgery
-  surgical_procedure_id:
+  surgical_procedure_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related
       records.> A unique identifier of each surgical procedure record, used to identify
       the correct surgical procedure records during data updates. <br>CDE ID = 14822135
@@ -1347,7 +1347,7 @@ PropDefinitions:
     Type: string
     Req: Preferred
   # radiotherapy
-  radiological_procedure_id:
+  radiological_procedure_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related
       records.> A unique identifier of each radiological procedure record, used to
       identify the correct radiological procedure record during data updates. <br>CDE
@@ -1476,7 +1476,7 @@ PropDefinitions:
       - Unknown
     Req: 'Yes'
   # subject_status
-  subject_status_id:
+  subject_status_record_id:
     Desc: <A unique sequence of characters used to identify a linkage between related
       records.> A unique identifier of each subject_status record, used to identify
       the correct subject_status records during data updates. The value of this property
@@ -1588,7 +1588,7 @@ PropDefinitions:
       - WITHDRAWAL OF CONSENT
     Req: 'No'
   # specimen 
-  specimen_id: # this will be the exact same value that the CMB uses for biospecimen_id
+  specimen_record_id: # this will be the exact same value that the CMB uses for biospecimen_id
     Desc: <A sequence of characters used to identify the kind of material that forms
       the sample.> <br>CDE ID =  14986441 <br>This property is used as the key via
       which child records, e.g. data files generated via Oncomine panel analyses,
@@ -1988,3 +1988,4 @@ PropDefinitions:
     Req: 'No'
     Tags:
       Template: 'No'
+      


### PR DESCRIPTION
This PR updates the names of properties that are designated as keys to make it more clear that the identifier should uniquely describe the record itself within the node and not describe the nature of a particular entity such as a therapy code.

The agreed upon format for key props is "node-name_record_id". The only nodes for which this update was not applied was deliberate in that those nodes already had properties that can be expected to be unique descriptors of each record submitted to that respective node.