### PR TITLE
Update props

### DIFF
--- a/model-desc/ctdc_model_properties_file.yaml
+++ b/model-desc/ctdc_model_properties_file.yaml
@@ -1620,7 +1620,7 @@ PropDefinitions:
     Src: CMB
     Type: string
     Req: 'Yes'
-    Key: true
+    Key: false
   parent_specimen_type: # this refers to the nature of the specimen originally isolated from the participant, and from which various aliquots and/or derivative biospecimens were subseuqently isolated
     Desc: <The kind of material that forms the parent sample as captured in the Ontology
       for Biobanking (OBIB).> <br>CDE ID = 14986443
@@ -1975,7 +1975,7 @@ PropDefinitions:
         Version: '1'
     Src: FNL
     Type: string
-    Req: 'Yes'
+    Req: 'No'
     Key: true
     Tags:
       Template: 'No'


### PR DESCRIPTION
This PR addresses validation errors from the CRDC Data Hub:

- Removes additional key prop from the Biospecimen node
- Changes the data_file_uuid property to not required so that example files do not have to include values for this property since we will not expect submitter to provide this.