### PR TITLE
Change requirement of key prop

### DIFF
--- a/model-desc/ctdc_model_properties_file.yaml
+++ b/model-desc/ctdc_model_properties_file.yaml
@@ -1978,7 +1978,7 @@ PropDefinitions:
     Req: 'No'
     Key: true
     Tags:
-      Template: 'No'
+      Template: 'Yes'
   data_file_location:
     Desc: <The specification of a node (file or directory) in a hierarchical file
       system where an electronic file is located.> The specific location within the


### PR DESCRIPTION
This PR changes the data_file_uuid property back to required since it is a "key" property for that node and it will for that reason be required.