### PR TITLE
Modifications to support CMB submission to DataHub

### DIFF
--- a/model-desc/ctdc_model_properties_file.yaml
+++ b/model-desc/ctdc_model_properties_file.yaml
@@ -600,7 +600,7 @@ PropDefinitions:
         Version: '1'
     Src: CMB
     Type: string
-    Req: 'Optional'
+    Req: Preferred
   income:
     Desc: <The amount of earnings made by a family in a year.> <br>CDE ID = 14834966
     Term:

--- a/model-desc/ctdc_model_properties_file.yaml
+++ b/model-desc/ctdc_model_properties_file.yaml
@@ -485,6 +485,7 @@ PropDefinitions:
       - American Indian or Alaska Native
       - Black or African American
       - Native Hawaiian or other Pacific Islander
+      - White
       - Not Reported
       - Unknown
     Req: 'Yes'
@@ -544,7 +545,7 @@ PropDefinitions:
       #- Refused to Answer # = Response Declined per CMB?
       - Response Declined # per CMB data values
       - Unknown # per CMB data values
-    Req: 'Yes'
+    Req: Preferred
   height:
     Desc: <The number that describes the vertical distance of an individual.> The
       height of the subject as of enrollment, measured in cm. <br>CDE ID = 2179643
@@ -599,7 +600,7 @@ PropDefinitions:
         Version: '1'
     Src: CMB
     Type: string
-    Req: 'Yes'
+    Req: 'Optional'
   income:
     Desc: <The amount of earnings made by a family in a year.> <br>CDE ID = 14834966
     Term:


### PR DESCRIPTION
This PR contains modifications to the CTDC data model to support submission of the Cancer Moonshot Biobank (CMB) data to the CRDC DataHub. 

- Added a permissible value of "White" to the race property, changed occupation property to Req: "No" as there is not a value for every subject.

- Changed reported_gender property from Required to Preferred as the not all subjects have values for this property.

- Changed occupation property from Required to Preferred as the not all subjects have values for this property.