### PR TITLE
CTDC-1309

### DIFF
--- a/model-desc/ctdc_model_properties_file.yaml
+++ b/model-desc/ctdc_model_properties_file.yaml
@@ -483,6 +483,7 @@ PropDefinitions:
     Src: CMB
     Enum: # Currently reflective only of the values used by the CMB
       - American Indian or Alaska Native
+      - Asian
       - Black or African American
       - Native Hawaiian or other Pacific Islander
       - White


### PR DESCRIPTION
Adding "Asian" as a permissible value to the race property. This is a valid permissible value per the NIH CDE repository and accommodates the CMB data.