### PR TITLE
CRDCDH-2457

### DIFF
--- a/model-navigator-resources/version-history.md
+++ b/model-navigator-resources/version-history.md
@@ -1,0 +1,3 @@
+### 1.2.0
+
+Release 1.2.0 adds file uuids to CTDC Example Files.


### PR DESCRIPTION
Adds a version-history.md file for the purpose of displaying the version history release notes within the CRDC Data Submission Hub.