### PR TITLE
CTDC-2041: SOP follow-up cleanup

### DIFF
--- a/SOP_CTDC_Data_Model_Contribution.md
+++ b/SOP_CTDC_Data_Model_Contribution.md
@@ -2,7 +2,7 @@
 
 **Repository:** CBIIT/ctdc-model\
 **Primary Branches:** develop (pre-release/testing) and prod (release)\
-**Model files:** YAML definitions and version-history.md
+**Model files:** YAML definitions in `model-desc/` and `model-navigator-resources/version-history.md`
 
 Downstream the CRDC Data Hub syncs via GitHub Actions + tags/releases
 
@@ -247,9 +247,7 @@ Before submitting a PR, verify that:
 
 1.  Verify the changes in the DEV/QA environments
 
-2.  Update any relevant documentation or release notes
-
-3.  Open a pull request from develop → prod when ready
+2.  Open a pull request from develop → prod when ready
 
 ## 🚀 9. Promoting Changes to prod
 
@@ -262,15 +260,12 @@ Before submitting a PR, verify that:
 
 ## 🔍 10. Downstream Validation
 
-- Once the release is cut and published, GitHub Actions will sync the
-  updated version downstream (for example, in the crdc-datahub-models
-  repository)
+- Confirm downstream propagation per Section 4, Step 15: verify the
+  updated CTDC entry in `cache/content.json` on the prod branch of
+  `CBIIT/crdc-datahub-models`.
 
-- Confirm that the change is reflected in the prod branch of
-  crdc-datahub-models
-
-- Validate that relevant environments have picked up the new model
-  version
+- Validate that the relevant CTDC environments (Dev, QA, Stage, Prod)
+  have picked up the new model version end-to-end.
 
 ## 💬 11. Support & Questions
 


### PR DESCRIPTION
## What changed

Three minor follow-up corrections to the SOP committed last week.
Documentation-only — no changes to the contribution workflow itself.

### 1. Section 8 — Removed vestigial release-notes step

**Before:**
1. Verify the changes in the DEV/QA environments
2. Update any relevant documentation or release notes
3. Open a pull request from develop → prod when ready

**After:**
1. Verify the changes in the DEV/QA environments
2. Open a pull request from develop → prod when ready

**Why:** Documentation/version-history updates are now captured in
Section 4 Step 4 as part of the per-PR file checklist, and release notes
are tied to the GitHub Release at Section 4 Step 14. The standalone
Section 8 step was a leftover from the prior workflow and created
ambiguity about *when* release notes should be written.

### 2. Section 10 — Deduplicated downstream verification

**Before:** Three generic bullets that re-described the downstream sync,
overlapping with the more concrete procedure already in Section 4
Step 15.

**After:** A pointer back to Section 4 Step 15 (which names the actual
verification path: `cache/content.json` on the prod branch of
`CBIIT/crdc-datahub-models`), plus the end-to-end environment
validation point that wasn't already covered there.

**Why:** Eliminates the redundancy without losing any information.
Single source of truth for the verification procedure.

### 3. Header line 4 — Named the actual paths

**Before:** `**Model files:** YAML definitions and version-history.md`

**After:** `**Model files:** YAML definitions in `model-desc/` and `model-navigator-resources/version-history.md``

**Why:** Brings the header into alignment with the file checklist in
Section 4 Step 4. Anyone scanning just the header now gets the actual
paths, matching what the body of the SOP references.

## SemVer impact

N/A — documentation-only change. No model files or schema affected.
No version bump required.

## Testing/validation performed

- [x] Markdown renders correctly in GitHub preview
- [x] All internal section references still resolve
- [x] No content removed beyond the explicit cleanups documented above
- [x] File size reduced by 39 bytes (net subtraction confirms this is
      a cleanup, not an additive change)

## Migration notes

None — no breaking changes, no schema impact, no downstream effects.

## Related

- Builds on the prior SOP corrections committed directly to `prod`
  (commit `177ad84`)
- No Jira ticket dependencies; promotion follows the standard
  develop → prod path