### PR TITLE
CTDC-2046: Update `data_file_type` to rename enum value and disable caDSR term

### DIFF
--- a/model-desc/ctdc_model_file.yaml
+++ b/model-desc/ctdc_model_file.yaml
@@ -3,7 +3,7 @@
 # Lower case names are labels for the entities
 Handle: CTDC
 
-Version: v1.23.0
+Version: v2.0.0
 
 Nodes:
   # node:

--- a/model-desc/ctdc_model_properties_file.yaml
+++ b/model-desc/ctdc_model_properties_file.yaml
@@ -3389,14 +3389,14 @@ PropDefinitions:
   data_file_type:
     Desc: The type of information contained in an electronic record. A curated indicator
       as to the type of content represented by the data file <br>CDE ID = 14824731
-    Term:
-      - Origin: caDSR 
-        Code: '14824731' 
-        Value: Electronic Data File Content Type
-        Version: '1'
-        Tags:
-          Provenance: CTDC
-          Added: 05-30-24
+    # Term:
+    #   - Origin: caDSR 
+    #     Code: '14824731' 
+    #     Value: Electronic Data File Content Type
+    #     Version: '1'
+    #     Tags:
+    #       Provenance: CTDC
+    #       Added: 05-30-24
     Src: Data Submitter
     #Type: string
     Enum:
@@ -3405,7 +3405,7 @@ PropDefinitions:
       - Investigator Report
       - Variant Call File
       - Variant Report
-      - Radiology Images
+      - Radiology Imaging
     Req: 'Yes'
   data_file_description:
     Desc: A free text field that can be used to document the content and other details

--- a/model-navigator-resources/version-history.md
+++ b/model-navigator-resources/version-history.md
@@ -1,5 +1,12 @@
 ## Release Notes - Clinical and Translational Data Commons (CTDC)
 
+### Data Model version 2.0.0
+
+Release Date: 5/13/26
+
+* Renames the `Radiology Images` enumerated value on the data\_file\_type property to `Radiology Imaging`. **Breaking change** — records previously submitted with `Radiology Images` will no longer validate against this version.
+* Disables the CDE binding for the data\_file\_type property (caDSR Code 14824731, Electronic Data File Content Type) pending re-binding. The property and its enumerations remain in place; only the term mapping is suspended.
+
 ### Data Model version 1.23.0
 
 * Added new properties to multiple nodes for the CIMAC-CIDC Network.


### PR DESCRIPTION
## Summary
- Rename the `data_file_type` enum value `Radiology Images` → `Radiology Imaging`.
- Comment out (rather than delete) the caDSR `Term` block for `data_file_type` (Code `14824731` — Electronic Data File Content Type, v1) to preserve it inline pending re-binding.
- Bump model version `v1.23.0` → `v2.0.0` in `model-desc/ctdc_model_file.yaml`.
- Add a v2.0.0 entry to `model-navigator-resources/version-history.md`.

## Why
- `Radiology Imaging` is the correct enum value; aligns with terminology used elsewhere.
- caDSR binding for `data_file_type` is being temporarily removed under CTDC-2046, but kept commented for traceability.
- Per the Data Model Owner's Guide, removing/renaming an enumeration value is a breaking change and requires a MAJOR version bump.
