### PR TITLE
CTDC-1799: Bug Fix for ECOG and Karnofsky Properties

### DIFF
--- a/model-desc/ctdc_model_file.yaml
+++ b/model-desc/ctdc_model_file.yaml
@@ -3,7 +3,7 @@
 # Lower case names are labels for the entities
 Handle: CTDC
 
-Version: v2.1.0
+Version: v2.1.1
 
 Nodes:
   # node:

--- a/model-desc/ctdc_model_properties_file.yaml
+++ b/model-desc/ctdc_model_properties_file.yaml
@@ -1275,32 +1275,30 @@ PropDefinitions:
         number
     Req: 'No'
   ecog_ps:
-    Desc: The functional level of the patient based on the Zubrod performance scale.
+    Desc: The functional level of the patient based on the Zubrod performance scale.  It describes a patient’s level of functioning in terms of their ability to care for themself, daily activity, and physical ability (walking, working, etc.).  With a value of 0 meaning no restrictions.
     Term:
       - Origin: caDSR
         Code: '88'
         Value: PERFORMANCE STATUS
+        Version: '5.3'
         Tags:
           Provenance: CIMAC-CIDC
-          Added: 04-17-26  
+          Added: 04-17-26
     Src: Data Submitter
     Type: integer
     Req: 'No'
   karnofsky:
-    Desc: The functional level of the patient based on the Karnofsky performance scale.
+    Desc: A standard way of measuring the ability of cancer patients to perform ordinary tasks. The Karnofsky Performance Status scores range from 0 to 100. A higher score means the patient is better able to carry out daily activities. Karnofsky Performance Status may be used to determine a patient's prognosis, to measure changes in a patient’s ability to function, or to decide if a patient could be included in a clinical trial.
     Term:
       - Origin: caDSR
         Code: '2003853'
         Value: PERFORMANCE STATUS
+        Version: '4.2'
         Tags:
-          Provenance: CIMAC-CIDC 
-          Added: 04-17-26  
+          Provenance: CIMAC-CIDC
+          Added: 04-17-26
     Src: Data Submitter
-    Type:
-      units: 
-        - percent
-      value_type: 
-        number    #percent between 0 and 100, where 0 is dead and 90% or higher is healthy
+    Type: integer
     Req: 'No'
 
   # Diagnosis Node

--- a/model-navigator-resources/version-history.md
+++ b/model-navigator-resources/version-history.md
@@ -1,5 +1,11 @@
 ## Release Notes - Clinical and Translational Data Commons (CTDC)
 
+### Data Model version 2.1.1
+
+* Updated definations to ecog_ps and karnofsky
+* Added CDE versions to ecog_ps and karnofsky that were previosly missing
+* Fixed property type for karnofsky, changed from percent to integer
+
 ### Data Model version 2.1.0
 
 * Adds 4 new properties to the program node: program_short_description, program_full_description, program_sort_order, and program_external_url.  These properties were added to support a new Program and Program Details page within the CTDC application. 


### PR DESCRIPTION
the property type for Karnofsky was wrong and instead of being a percent it should have been an integer
updated the definition to be more accurate